### PR TITLE
Use `proc-macro-crate` for resolving crate identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,22 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -181,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -383,6 +420,7 @@ dependencies = [
 name = "safe_math_macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -428,6 +466,23 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -605,6 +660,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/safe_math_macros/Cargo.toml
+++ b/safe_math_macros/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 syn = { version = "2", features = ["full", "fold"] }
 quote = "1"
 proc-macro2 = "1"
+proc-macro-crate = "3"

--- a/safe_math_macros/src/lib.rs
+++ b/safe_math_macros/src/lib.rs
@@ -1,6 +1,8 @@
 use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::Span;
 use quote::quote;
-use syn::{BinOp, Expr, ExprBinary, ItemFn, parse_macro_input};
+use syn::{BinOp, Expr, ExprBinary, Ident, ItemFn, parse_macro_input};
 
 #[proc_macro_attribute]
 pub fn safe_math(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -14,8 +16,16 @@ pub fn safe_math(_attr: TokenStream, item: TokenStream) -> TokenStream {
 fn rewrite_block(block: syn::Block) -> syn::Block {
     use syn::fold::{self, Fold};
     struct MathRewriter;
+
     impl Fold for MathRewriter {
         fn fold_expr(&mut self, expr: Expr) -> Expr {
+            let safe_math_crate = {
+                match crate_name("safe_math").expect("safe_math crate not found") {
+                    FoundCrate::Itself => Ident::new("::safe_math", Span::call_site()),
+                    FoundCrate::Name(crate_name) => Ident::new(&crate_name, Span::call_site()),
+                }
+            };
+
             match expr {
                 Expr::Binary(ExprBinary {
                     left,
@@ -25,7 +35,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { ::safe_math::safe_add(#left, #right)? }
+                    syn::parse_quote! { #safe_math_crate::safe_add(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -35,7 +45,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { ::safe_math::safe_sub(#left, #right)? }
+                    syn::parse_quote! { #safe_math_crate::safe_sub(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -45,7 +55,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { ::safe_math::safe_mul(#left, #right)? }
+                    syn::parse_quote! { #safe_math_crate::safe_mul(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -55,7 +65,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { ::safe_math::safe_div(#left, #right)? }
+                    syn::parse_quote! { #safe_math_crate::safe_div(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -65,7 +75,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { ::safe_math::safe_rem(#left, #right)? }
+                    syn::parse_quote! { #safe_math_crate::safe_rem(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -75,7 +85,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { #left = ::safe_math::safe_add(#left, #right)? }
+                    syn::parse_quote! { #left = #safe_math_crate::safe_add(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -85,7 +95,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { #left = ::safe_math::safe_sub(#left, #right)? }
+                    syn::parse_quote! { #left = #safe_math_crate::safe_sub(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -95,7 +105,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { #left = ::safe_math::safe_mul(#left, #right)? }
+                    syn::parse_quote! { #left = #safe_math_crate::safe_mul(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -105,7 +115,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { #left = ::safe_math::safe_div(#left, #right)? }
+                    syn::parse_quote! { #left = #safe_math_crate::safe_div(#left, #right)? }
                 }
                 Expr::Binary(ExprBinary {
                     left,
@@ -115,7 +125,7 @@ fn rewrite_block(block: syn::Block) -> syn::Block {
                 }) => {
                     let left = self.fold_expr(*left);
                     let right = self.fold_expr(*right);
-                    syn::parse_quote! { #left = ::safe_math::safe_rem(#left, #right)? }
+                    syn::parse_quote! { #left = #safe_math_crate::safe_rem(#left, #right)? }
                 }
                 _ => fold::fold_expr(self, expr),
             }


### PR DESCRIPTION
This PR uses [`proc-macro-crate`](https://crates.io/crates/proc-macro-crate) for resolving the `safe_math` crate identifier within the proc macro. This allows it to resolve the crate name even if there are name collisions, or if the crate has been renamed in the Cargo manifest.

This handles the same issue with the absolute identifier as fixed in [this PR](https://github.com/GotenJBZ/safe-math-rs/pull/2), while handling edge cases with renaming crates. 