### PR TITLE
Fix: remove unnecessary Debug bound from `SafeMathOps`

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,9 +1,7 @@
-use core::fmt::Debug;
-
 use crate::error::SafeMathResult;
 
 /// Trait that defines safe mathematical operations for a type.
-pub trait SafeMathOps: Copy + Debug {
+pub trait SafeMathOps: Copy {
     fn safe_add(self, rhs: Self) -> SafeMathResult<Self>;
     fn safe_sub(self, rhs: Self) -> SafeMathResult<Self>;
     fn safe_mul(self, rhs: Self) -> SafeMathResult<Self>;


### PR DESCRIPTION
the Debug trait is unnecessary, just remove it