### PR TITLE
Add NotImplemented error for derive macro

### DIFF
--- a/safe_math_macros/src/derive/mod.rs
+++ b/safe_math_macros/src/derive/mod.rs
@@ -23,7 +23,7 @@ macro_rules! generate_op_impl {
             }
         } else {
             quote! {
-                unimplemented!()
+                Err(SafeMathError::NotImplemented)
             }
         };
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,10 @@ pub enum SafeMathError {
     Overflow,
     /// Attempted to divide (or take remainder) by zero.
     DivisionByZero,
+
+    #[cfg(feature = "derive")]
+    /// The operation is not implemented for the given type.
+    NotImplemented,
 }
 
 impl fmt::Display for SafeMathError {
@@ -14,6 +18,8 @@ impl fmt::Display for SafeMathError {
         match self {
             SafeMathError::Overflow => write!(f, "arithmetic overflow"),
             SafeMathError::DivisionByZero => write!(f, "division by zero"),
+            #[cfg(feature = "derive")]
+            SafeMathError::NotImplemented => write!(f, "operation not implemented"),
         }
     }
 }


### PR DESCRIPTION
Add `NotImplemented` error variant and use it in derive macro

- Introduce `SafeMathError::NotImplemented` (feature = \"derive\")
- Replace `unimplemented!()` with `Err(SafeMathError::NotImplemented)` in macro

