### PR TITLE
prevent silent runtime failures in derive macro (#28, #29)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-derive = ["safe_math_macros/derive"]
+derive = ["safe_math_macros/derive", "num-traits"]
 
 [[example]]
 name = "basic"
@@ -23,7 +23,9 @@ path = "examples/derive.rs"
 required-features = ["derive"]
 
 [dependencies]
+num-traits = { version = "0.2", optional = true }
 safe_math_macros = { path = "./safe_math_macros" }
+
 
 [dev-dependencies]
 proptest = "1.7.0"

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,5 +1,5 @@
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
-use safe_math::{safe_math, SafeMathError, SafeMathOps};
+use safe_math::{safe_math, SafeMathOps};
 use std::ops::{Add, Div, Mul, Sub};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, SafeMathOps)]

--- a/safe_math_macros/src/derive/mod.rs
+++ b/safe_math_macros/src/derive/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
+use quote::{format_ident, quote};
 use std::collections::HashSet;
 use syn::{parse_macro_input, DeriveInput, Meta};
 
@@ -16,17 +16,48 @@ pub(crate) fn derive_safe_math_ops(tokens: TokenStream) -> TokenStream {
         .into()
 }
 
-macro_rules! generate_op_impls {
-    ( $checked_ops:expr; $( ($op:ident, $impl_name:ident) ),* $(,)? ) => {
+macro_rules! gen_impl {
+    ( $checked_ops:expr, $( ($var:ident, $op:ident, $trait:ident) ),* $(,)? ) => {
         $(
-            let checked_op_fn = syn::Ident::new(&format!("checked_{}", stringify!($op)), proc_macro2::Span::call_site());
-            let $impl_name = if $checked_ops.contains(stringify!($op)) {
-                quote! { self.#checked_op_fn(&rhs).ok_or(SafeMathError::Overflow) }
+            let $var = if $checked_ops.contains(stringify!($op).trim_start_matches("safe_")) {
+                quote! { <Self as ::safe_math::$trait>::$op(self, rhs) }
             } else {
-                quote! { Err(SafeMathError::NotImplemented) }
+                quote! { Err(::safe_math::SafeMathError::NotImplemented) }
             };
         )*
     };
+}
+
+// Macro to generate extra_impls TokenStream2 based on checked operations
+macro_rules! gen_extra_impls {
+    ( $checked_ops:expr, $name_ident:ident, $( ($op_lit:literal, $trait:ident, $checked_method:ident, $use_or_else:expr, $err_expr:expr) ),* $(,)? ) => {{
+        let mut impls = TokenStream2::new();
+        $(
+            if $checked_ops.contains($op_lit) {
+                let fn_ident = format_ident!("safe_{}", $op_lit);
+                let trait_ident = syn::Ident::new(stringify!($trait), proc_macro2::Span::call_site());
+                let method_ident = syn::Ident::new(stringify!($checked_method), proc_macro2::Span::call_site());
+                if $use_or_else {
+                    impls.extend(quote! {
+                        impl ::safe_math::#trait_ident for #$name_ident {
+                            fn #fn_ident(self, rhs: Self) -> ::safe_math::SafeMathResult<Self> {
+                                self.#method_ident(&rhs).ok_or_else(|| { $err_expr })
+                            }
+                        }
+                    });
+                } else {
+                    impls.extend(quote! {
+                        impl ::safe_math::#trait_ident for #$name_ident {
+                            fn #fn_ident(self, rhs: Self) -> ::safe_math::SafeMathResult<Self> {
+                                self.#method_ident(&rhs).ok_or({ $err_expr })
+                            }
+                        }
+                    });
+                }
+            }
+        )*
+        impls
+    }};
 }
 
 fn expand_derive_safe_math_ops(input: DeriveInput) -> syn::Result<TokenStream2> {
@@ -97,16 +128,56 @@ fn expand_derive_safe_math_ops(input: DeriveInput) -> syn::Result<TokenStream2> 
         ));
     }
 
-    generate_op_impls!(
-        checked_ops;
-        (add, add_impl),
-        (sub, sub_impl),
-        (mul, mul_impl),
-        (div, div_impl),
-        (rem, rem_impl),
-    );
-
     let name = &input.ident;
+
+    gen_impl!(
+        checked_ops,
+        (add_impl, safe_add, SafeAdd),
+        (sub_impl, safe_sub, SafeSub),
+        (mul_impl, safe_mul, SafeMul),
+        (div_impl, safe_div, SafeDiv),
+        (rem_impl, safe_rem, SafeRem),
+    );
+    // Use macro to generate extra_impls
+    let extra_impls = gen_extra_impls!(
+        checked_ops,
+        name,
+        (
+            "add",
+            SafeAdd,
+            checked_add,
+            false,
+            ::safe_math::SafeMathError::Overflow
+        ),
+        (
+            "sub",
+            SafeSub,
+            checked_sub,
+            false,
+            ::safe_math::SafeMathError::Overflow
+        ),
+        (
+            "mul",
+            SafeMul,
+            checked_mul,
+            false,
+            ::safe_math::SafeMathError::Overflow
+        ),
+        ("div", SafeDiv, checked_div, true, {
+            if rhs == Self::default() {
+                ::safe_math::SafeMathError::DivisionByZero
+            } else {
+                ::safe_math::SafeMathError::Overflow
+            }
+        }),
+        (
+            "rem",
+            SafeRem,
+            checked_rem,
+            false,
+            ::safe_math::SafeMathError::DivisionByZero
+        ),
+    );
 
     Ok(quote! {
         impl ::safe_math::SafeMathOps for #name {
@@ -130,5 +201,6 @@ fn expand_derive_safe_math_ops(input: DeriveInput) -> syn::Result<TokenStream2> 
                 #rem_impl
             }
         }
+        #extra_impls
     })
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,7 +1,11 @@
 use crate::error::{SafeMathError, SafeMathResult};
+#[cfg(not(feature = "derive"))]
 use crate::ops::SafeMathOps;
+#[cfg(feature = "derive")]
+use crate::ops::{SafeAdd, SafeDiv, SafeMathOps, SafeMul, SafeRem, SafeSub};
 
 // === Implementations for integer types =====================================
+#[cfg(not(feature = "derive"))]
 macro_rules! impl_safe_math_int {
     ($($t:ty),*) => {
         $(
@@ -37,9 +41,11 @@ macro_rules! impl_safe_math_int {
     };
 }
 
+#[cfg(not(feature = "derive"))]
 impl_safe_math_int!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, isize);
 
 // === Implementations for floating-point types ==============================
+#[cfg(not(feature = "derive"))]
 macro_rules! impl_safe_math_float {
     ($($t:ty),*) => {
         $(
@@ -59,10 +65,12 @@ macro_rules! impl_safe_math_float {
     };
 }
 
+#[cfg(not(feature = "derive"))]
 impl_safe_math_float!(f32, f64);
 
 // === Crate-internal generic helpers ========================================
 
+#[cfg(not(feature = "derive"))]
 macro_rules! impl_safe_math_ops {
     ($($op:ident),*) => {
         $(
@@ -74,4 +82,98 @@ macro_rules! impl_safe_math_ops {
     };
 }
 
+#[cfg(not(feature = "derive"))]
 impl_safe_math_ops!(safe_add, safe_sub, safe_mul, safe_div, safe_rem);
+
+#[cfg(feature = "derive")]
+macro_rules! impl_safe_math_ops {
+    ($($op:ident, $trait:ident),*) => {
+        $(
+            #[inline(always)]
+            pub fn $op<T: $trait>(a: T, b: T) -> SafeMathResult<T> {
+                a.$op(b)
+            }
+        )*
+    };
+}
+
+#[cfg(feature = "derive")]
+impl_safe_math_ops!(
+    safe_add, SafeAdd, safe_sub, SafeSub, safe_mul, SafeMul, safe_div, SafeDiv, safe_rem, SafeRem
+);
+
+// === Implementations for when derive feature is enabled ====================
+
+#[cfg(feature = "derive")]
+macro_rules! impl_safe_math_int {
+    ($($t:ty),*) => {
+        $(
+            impl SafeAdd for $t {
+                #[inline(always)]
+                fn safe_add(self, rhs: Self) -> SafeMathResult<Self> {
+                    self.checked_add(rhs).ok_or(SafeMathError::Overflow)
+                }
+            }
+
+            impl SafeSub for $t {
+                #[inline(always)]
+                fn safe_sub(self, rhs: Self) -> SafeMathResult<Self> {
+                    self.checked_sub(rhs).ok_or(SafeMathError::Overflow)
+                }
+            }
+
+            impl SafeMul for $t {
+                #[inline(always)]
+                fn safe_mul(self, rhs: Self) -> SafeMathResult<Self> {
+                    self.checked_mul(rhs).ok_or(SafeMathError::Overflow)
+                }
+            }
+
+            impl SafeDiv for $t {
+                #[inline(always)]
+                fn safe_div(self, rhs: Self) -> SafeMathResult<Self> {
+                    self.checked_div(rhs).ok_or_else(|| {
+                        if rhs == 0 {
+                            SafeMathError::DivisionByZero
+                        } else {
+                            SafeMathError::Overflow // e.g. i32::MIN / -1
+                        }
+                    })
+                }
+            }
+
+            impl SafeRem for $t {
+                #[inline(always)]
+                fn safe_rem(self, rhs: Self) -> SafeMathResult<Self> {
+                    self.checked_rem(rhs).ok_or(SafeMathError::DivisionByZero)
+                }
+            }
+
+            impl SafeMathOps for $t {
+                #[inline(always)]
+                fn safe_add(self, rhs: Self) -> SafeMathResult<Self> {
+                    <Self as SafeAdd>::safe_add(self, rhs)
+                }
+                #[inline(always)]
+                fn safe_sub(self, rhs: Self) -> SafeMathResult<Self> {
+                    <Self as SafeSub>::safe_sub(self, rhs)
+                }
+                #[inline(always)]
+                fn safe_mul(self, rhs: Self) -> SafeMathResult<Self> {
+                    <Self as SafeMul>::safe_mul(self, rhs)
+                }
+                #[inline(always)]
+                fn safe_div(self, rhs: Self) -> SafeMathResult<Self> {
+                    <Self as SafeDiv>::safe_div(self, rhs)
+                }
+                #[inline(always)]
+                fn safe_rem(self, rhs: Self) -> SafeMathResult<Self> {
+                    <Self as SafeRem>::safe_rem(self, rhs)
+                }
+            }
+        )*
+    };
+}
+
+#[cfg(feature = "derive")]
+impl_safe_math_int!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, isize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,14 @@ mod ops;
 
 // Re-export the most relevant items at the crate root for a clean API.
 pub use error::{SafeMathError, SafeMathResult};
+#[cfg(not(feature = "derive"))]
 pub use ops::SafeMathOps;
+#[cfg(feature = "derive")]
+pub use ops::{SafeAdd, SafeDiv, SafeMathOps, SafeMul, SafeRem, SafeSub};
 
 // These helper functions are intentionally re-exported because the macro expands
 // to them, and users may want to call them directly in generic contexts.
+#[cfg(not(feature = "derive"))]
+pub use impls::{safe_add, safe_div, safe_mul, safe_rem, safe_sub};
+#[cfg(feature = "derive")]
 pub use impls::{safe_add, safe_div, safe_mul, safe_rem, safe_sub};

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,44 @@
 use crate::error::SafeMathResult;
 
 /// Trait that defines safe mathematical operations for a type.
+#[cfg(not(feature = "derive"))]
+pub trait SafeMathOps: Copy {
+    fn safe_add(self, rhs: Self) -> SafeMathResult<Self>;
+    fn safe_sub(self, rhs: Self) -> SafeMathResult<Self>;
+    fn safe_mul(self, rhs: Self) -> SafeMathResult<Self>;
+    fn safe_div(self, rhs: Self) -> SafeMathResult<Self>;
+    fn safe_rem(self, rhs: Self) -> SafeMathResult<Self>;
+}
+
+#[cfg(feature = "derive")]
+pub use num_traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub};
+
+#[cfg(feature = "derive")]
+pub trait SafeAdd: Copy + CheckedAdd {
+    fn safe_add(self, rhs: Self) -> SafeMathResult<Self>;
+}
+
+#[cfg(feature = "derive")]
+pub trait SafeSub: Copy + CheckedSub {
+    fn safe_sub(self, rhs: Self) -> SafeMathResult<Self>;
+}
+
+#[cfg(feature = "derive")]
+pub trait SafeMul: Copy + CheckedMul {
+    fn safe_mul(self, rhs: Self) -> SafeMathResult<Self>;
+}
+
+#[cfg(feature = "derive")]
+pub trait SafeDiv: Copy + CheckedDiv {
+    fn safe_div(self, rhs: Self) -> SafeMathResult<Self>;
+}
+
+#[cfg(feature = "derive")]
+pub trait SafeRem: Copy + CheckedRem {
+    fn safe_rem(self, rhs: Self) -> SafeMathResult<Self>;
+}
+
+#[cfg(feature = "derive")]
 pub trait SafeMathOps: Copy {
     fn safe_add(self, rhs: Self) -> SafeMathResult<Self>;
     fn safe_sub(self, rhs: Self) -> SafeMathResult<Self>;


### PR DESCRIPTION
This pr strengthens compile-time checks introduced by the macro/crate to ensure that missing functionality is caught during compilation rather than at runtime, see #29 and #28 

## problems

1. There is currently duplicated code between the implementation with the derive feature and the one without it.

2. Floating-point numbers are not supported with this approach, since they do not implement the standard checked_* methods.

## Proposed Solutions

1. We should probably simplify the codebase and use only the version of the feature flag, we need to benchmark a bit.
2.  One possible solution is to define a custom `Checked*` trait inside the crate:
    - For all types except floats, this would be a wrapper around `checked_*`
    - For floats, it would provide a custom implementation that prevents `Inf` and `NaN`.











