### PR TITLE
Refactoring and added function-like macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    ".",
-    "safe_math_macros",
-    "tests/generated"
-]
+members = ["safe_math_macros", "tests/generated"]
 
 [package]
 name = "safe_math"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@
 // ---------------------------------------------------------------------------
 
 // Re-export the procedural macro so users can simply `use safe_math::safe_math`.
-pub use safe_math_macros::safe_math;
 #[cfg(feature = "derive")]
 pub use safe_math_macros::SafeMathOps;
+pub use safe_math_macros::{safe_math, safe_math_block};
 
 // Internal modules
 mod error;

--- a/tests/generated/generator.rs
+++ b/tests/generated/generator.rs
@@ -10,15 +10,19 @@ pub const NUM_TEST_CASES: usize = 50;
 const OPERATORS: [&str; 5] = ["+", "-", "*", "/", "%"];
 
 /// Corresponding checked methods for each operator
-const CHECKED_OPERATORS: [&str; 5] = ["checked_add", "checked_sub", "checked_mul", "checked_div", "checked_rem"];
+const CHECKED_OPERATORS: [&str; 5] = [
+    "checked_add",
+    "checked_sub",
+    "checked_mul",
+    "checked_div",
+    "checked_rem",
+];
 
 /// All numeric types that will be tested
 const NUMERIC_TYPES: [&str; 12] = [
     // Unsigned integers
-    "u8", "u16", "u32", "u64", "u128",
-    // Signed integers  
-    "i8", "i16", "i32", "i64", "i128",
-    // usize
+    "u8", "u16", "u32", "u64", "u128", // Signed integers
+    "i8", "i16", "i32", "i64", "i128", // usize
     "usize", "isize",
     // TODO: Floating point
     // "f32", "f64",
@@ -43,7 +47,7 @@ impl ExpressionBuilder {
     }
 
     /// Adds a new operation to both expressions
-    /// 
+    ///
     /// # Arguments
     /// * `op` - The regular operator (e.g., "+")
     /// * `checked_op` - The corresponding checked method (e.g., "checked_add")
@@ -57,27 +61,23 @@ impl ExpressionBuilder {
 }
 
 /// Generates a single test case with a random number of arguments and operations
-/// 
+///
 /// # Arguments
 /// * `test_number` - The index of this test case, used to generate unique function names
 /// * `numeric_type` - The type of the numeric arguments
 fn generate_single_test(test_number: usize, numeric_type: &str) -> String {
     let mut rng = rand::rng();
-    
+
     // Generate between 2 and 10 arguments
     let num_args = rng.random_range(2..=10);
     let arg_names: Vec<String> = (1..=num_args).map(|i| format!("a{i}")).collect();
-    
+
     let mut builder = ExpressionBuilder::new(&arg_names[0]);
-    
+
     // Add random operations with the remaining arguments
     for arg in arg_names.iter().skip(1) {
         let op_idx = rng.random_range(0..OPERATORS.len());
-        builder.add_operation(
-            OPERATORS[op_idx],
-            CHECKED_OPERATORS[op_idx],
-            arg
-        );
+        builder.add_operation(OPERATORS[op_idx], CHECKED_OPERATORS[op_idx], arg);
     }
 
     // Generate appropriate random value based on type
@@ -96,9 +96,9 @@ fn generate_single_test(test_number: usize, numeric_type: &str) -> String {
         "f64" => "rng.random::<f64>()",
         "usize" => "rng.random::<u64>() as usize",
         "isize" => "rng.random::<i64>() as isize",
-        _ => unreachable!()
+        _ => unreachable!(),
     };
-    
+
     format!(
         r#"
 #[test]
@@ -118,58 +118,104 @@ fn test_generated_{}_{}_equivalence() {{
         Ok(result)
     }}
 
+    // 3. Using the safe_math_block macro
+    fn with_function_macro({}) -> Result<{}, ()> {{
+        #[allow(unused_parens)]
+        let result = {{
+            safe_math_block! {{{{
+                {}
+        }}}}
+        }};
+        Ok(result)
+    }}
+
     // Test with multiple random inputs to increase coverage
     let mut rng = rand::rng();
     for _ in 0..100 {{
         // Generate random inputs
         let inputs = [{}];
-        
+
         // Call both functions with the same inputs
         let macro_result = with_macro({});
         let checked_result = with_checked({});
+        let function_macro_result = with_function_macro({});
 
         // Verify that both functions produce exactly the same result
-        assert_eq!(
-            macro_result, 
-            checked_result,
+        assert!(
+            macro_result == checked_result &&
+            macro_result == function_macro_result,
             "safe_math macro and checked operations produced different results for inputs: {{inputs:?}}"
         );
     }}
 }}
 "#,
-        numeric_type.replace(".", "_"),  // Sostituisce il punto con underscore per f32/f64
+        numeric_type.replace(".", "_"), // Sostituisce il punto con underscore per f32/f64
         test_number,
         // Function arguments for with_macro
-        arg_names.iter().map(|a| format!("{a}: {numeric_type}")).collect::<Vec<_>>().join(", "),
+        arg_names
+            .iter()
+            .map(|a| format!("{a}: {numeric_type}"))
+            .collect::<Vec<_>>()
+            .join(", "),
         numeric_type,
         // Expression for with_macro
         builder.expr,
         // Function arguments for with_checked
-        arg_names.iter().map(|a| format!("{a}: {numeric_type}")).collect::<Vec<_>>().join(", "),
+        arg_names
+            .iter()
+            .map(|a| format!("{a}: {numeric_type}"))
+            .collect::<Vec<_>>()
+            .join(", "),
         numeric_type,
         // Expression for with_checked
         builder.expr_safe,
+        // Function arguments for with_function_macro
+        arg_names
+            .iter()
+            .map(|a| format!("{a}: {numeric_type}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        numeric_type,
+        // Expression for with_function_macro
+        builder.expr,
         // Random input generation
-        arg_names.iter().map(|_| random_gen).collect::<Vec<_>>().join(", "),
+        arg_names
+            .iter()
+            .map(|_| random_gen)
+            .collect::<Vec<_>>()
+            .join(", "),
         // Arguments for with_macro call
-        (0..arg_names.len()).map(|i| format!("inputs[{i}]")).collect::<Vec<_>>().join(", "),
+        (0..arg_names.len())
+            .map(|i| format!("inputs[{i}]"))
+            .collect::<Vec<_>>()
+            .join(", "),
         // Arguments for with_checked call
-        (0..arg_names.len()).map(|i| format!("inputs[{i}]")).collect::<Vec<_>>().join(", ")
+        (0..arg_names.len())
+            .map(|i| format!("inputs[{i}]"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        // Arguments for with_function_macro call
+        (0..arg_names.len())
+            .map(|i| format!("inputs[{i}]"))
+            .collect::<Vec<_>>()
+            .join(", "),
     )
 }
 
 /// Generates all test cases and combines them into a single string
 pub fn generate_test_cases() -> String {
-    let mut test_file = String::from(r#"
+    let mut test_file = String::from(
+        r#"
 #[cfg(test)]
-use safe_math::safe_math;
+use safe_math::{safe_math, safe_math_block};
 #[cfg(test)]
 use rand::Rng;
 
 // This file is auto-generated. Do not edit manually.
 // Each test verifies that the safe_math macro produces identical results
 // to using checked arithmetic operations directly.
-"#);
+"#,
+    );
 
     // Generate test cases for each numeric type
     for type_name in NUMERIC_TYPES.iter() {
@@ -179,4 +225,4 @@ use rand::Rng;
     }
 
     test_file
-} 
+}

--- a/tests/generated/generator.rs
+++ b/tests/generated/generator.rs
@@ -122,9 +122,9 @@ fn test_generated_{}_{}_equivalence() {{
     fn with_function_macro({}) -> Result<{}, ()> {{
         #[allow(unused_parens)]
         let result = {{
-            safe_math_block! {{{{
+            safe_math_block! {{
                 {}
-        }}}}
+        }}
         }};
         Ok(result)
     }}

--- a/tests/generated/src/lib.rs
+++ b/tests/generated/src/lib.rs
@@ -1,1 +1,2 @@
+#![allow(unused_parens)]
 include!(concat!(env!("OUT_DIR"), "/generated_tests.rs"));


### PR DESCRIPTION
- Refactored `MathRewriter` struct to now be in parent scope rather than specific to `rewrite_block` function
- Replaced `rewrite_block` function with a reference to `MathRewriter.fold_block` as it was simply a wrapper for that method
- Added function-like procedural macro for creating singular safe math expressions rather than restricting it to full functions
- Removed '.' in workspace members (this is implied as the workspace Cargo.toml is also a package Cargo.toml)
- Re-export `safe_math_block` from `safe_math` crate